### PR TITLE
Remove all push triggers from workflows

### DIFF
--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -1,6 +1,5 @@
 name: Check Sphinx external links
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 5 * * 0'  # once every Sunday at midnight ET

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,5 @@
 name: Codespell
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,6 +1,5 @@
 name: Ruff
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -1,6 +1,5 @@
 name: Run all tests
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 5 * * 0'  # once every Sunday at midnight ET

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -1,6 +1,5 @@
 name: Run code coverage
 on:
-  push:
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Including the push trigger for extensions might make sense in general because not every user follows the classic PR workflow within their group

But we are, and so it's annoyingly resulting in duplicate runs on PRs (the pushes get skipped of course, but it still spams the window)