### PR TITLE
Generalize light source

### DIFF
--- a/spec/ndx-patterned-ogen.extensions.yaml
+++ b/spec/ndx-patterned-ogen.extensions.yaml
@@ -34,6 +34,7 @@ groups:
         shape:
           -
           -
+          
   - neurodata_type_def: OptogeneticStimulus3DPattern
     neurodata_type_inc: LabMetaData
     doc: Container to store the information about a generic 3D stimulus pattern (spatial information).
@@ -89,6 +90,7 @@ groups:
         dtype: text
         doc: Describe any additional details about the pattern.
         required: false
+        
   - neurodata_type_def: TemporalFocusing
     neurodata_type_inc: LabMetaData
     doc: Container to store the parameters defining a temporal focusing beam-shaping.
@@ -107,6 +109,7 @@ groups:
         dtype: text
         doc: Describe any additional details about the pattern.
         required: false
+        
   - neurodata_type_def: PatternedOptogeneticStimulusSite
     neurodata_type_inc: OptogeneticStimulusSite
     doc: Patterned optogenetic stimulus site.
@@ -122,6 +125,7 @@ groups:
         target_type: Device
         doc: Spatial light modulator used to generate photostimulation pattern.
         required: false
+        
   - neurodata_type_def: SpatialLightModulator2D
     neurodata_type_inc: Device
     doc: 2D spatial light modulator used in the experiment.
@@ -138,6 +142,7 @@ groups:
           - width, height
         shape:
           - 2
+          
   - neurodata_type_def: SpatialLightModulator3D
     neurodata_type_inc: Device
     doc: 3D spatial light modulator used in the experiment.
@@ -154,16 +159,22 @@ groups:
           - width, height, depth
         shape:
           - 3
+          
   - neurodata_type_def: LightSource
     neurodata_type_inc: Device
-    doc: Light source used in the experiment.
+    doc: Light source used to illuminate an imaging space.
     attributes:
-      - name: stimulation_wavelength_in_nm
-        dtype: numeric
-        doc: Excitation wavelength of stimulation light (nanometers).
+      - name: model
+        dtype: text
+        doc: Model identifier of the light source device.
+        required: false
       - name: filter_description
         dtype: text
-        doc: Filter used to obtain the excitation wavelength of stimulation light, e.g. 'Short pass at 1040 nm'.
+        doc: Filter used to obtain the excitation wavelength of light, e.g. 'Short pass at 1040 nm'.
+        required: false
+      - name: excitation_wavelength_in_nm
+        dtype: numeric
+        doc: Excitation wavelength of light, in nanometers.
         required: false
       - name: peak_power_in_W
         dtype: numeric
@@ -185,10 +196,7 @@ groups:
         dtype: numeric
         doc: If device is pulsed light source, pulse rate (in Hz) used for stimulation.
         required: false
-      - name: model
-        dtype: text
-        doc: Model of light source device.
-        required: false
+        
   - neurodata_type_def: OptogeneticStimulusTarget
     neurodata_type_inc: LabMetaData
     doc: Container to store the targated rois in a photostimulation experiment.
@@ -200,6 +208,7 @@ groups:
         neurodata_type_inc: DynamicTableRegion
         doc: A table region referencing a PlaneSegmentation object storing segmented ROIs that receive photostimulation.
         quantity: "?"
+        
   - neurodata_type_def: PatternedOptogeneticStimulusTable
     neurodata_type_inc: TimeIntervals
     doc: Table to hold all patterned optogenetic stimulus onsets.

--- a/spec/ndx-patterned-ogen.extensions.yaml
+++ b/spec/ndx-patterned-ogen.extensions.yaml
@@ -162,7 +162,7 @@ groups:
           
   - neurodata_type_def: LightSource
     neurodata_type_inc: Device
-    doc: Light source used to illuminate an imaging space.
+    doc: Light source used in the experiment.
     attributes:
       - name: model
         dtype: text


### PR DESCRIPTION
Rename `stimulation_wavelength_in_nm` to `excitation_wavelength_in_nm` to be cross-compatible with `ndx-microscopy`

Also rearranged the order of definitions and generalized some docs

@alessandratrapani Would you know where else to propagate this change throughout this repo?